### PR TITLE
Add generation of __eq__ and __ne__ based on synthetic member list

### DIFF
--- a/synthetic/__init__.py
+++ b/synthetic/__init__.py
@@ -2,16 +2,20 @@
 from .i_naming_convention import INamingConvention
 from .naming_convention_camel_case import NamingConventionCamelCase
 from .naming_convention_underscore import NamingConventionUnderscore
-from .decorators import naming_convention, synthesize_constructor, synthesize_member, synthesize_property, \
-                        namingConvention, synthesizeConstructor, synthesizeMember, synthesizeProperty
+from .decorators import naming_convention, synthesize_constructor, synthesize_equality, \
+                        synthesize_member, synthesize_property, \
+                        namingConvention, synthesizeConstructor, synthesizeEquality, \
+                        synthesizeMember, synthesizeProperty
 
 from .property_delegate import InvalidPropertyOverrideError
 from .synthetic_meta_data import DuplicateMemberNameError
 
 __all__ = ['DuplicateMemberNameError', 'InvalidPropertyOverrideError', 'INamingConvention',
            'NamingConventionCamelCase', 'NamingConventionUnderscore',
-           'namingConvention', 'synthesizeConstructor', 'synthesizeMember', 'synthesizeProperty',
-           'naming_convention', 'synthesize_constructor', 'synthesize_member', 'synthesize_property']
+           'namingConvention', 'synthesizeEquality', 'synthesizeConstructor',
+           'synthesizeMember', 'synthesizeProperty',
+           'naming_convention', 'synthesize_equality', 'synthesize_constructor',
+           'synthesize_member', 'synthesize_property']
 
 __version__ = "0.4.14"
 

--- a/synthetic/decorators.py
+++ b/synthetic/decorators.py
@@ -191,6 +191,12 @@ def synthesizeConstructor():
 """
     return SyntheticDecoratorFactory().syntheticConstructorDecorator()
 
+def synthesizeEquality():
+    """
+    This class decorator will override the class's __eq__ and __neq__ operations
+    to be based on comparing the values of the synthetic members.
+    """
+    return SyntheticDecoratorFactory().syntheticEqualityDecorator()
 
 def namingConvention(namingConvention):
     """
@@ -213,3 +219,4 @@ def naming_convention(naming_convention):
     return SyntheticDecoratorFactory().namingConventionDecorator(naming_convention)  
 
 synthesize_constructor = synthesizeConstructor
+synthesize_equality = synthesizeEquality

--- a/synthetic/synthetic_comparison_factory.py
+++ b/synthetic/synthetic_comparison_factory.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# Created on Oct 30, 2016
+import inspect
+
+from contracts import new_contract, contract
+
+from .synthetic_member import SyntheticMember
+
+new_contract('SyntheticMember', SyntheticMember)
+
+
+class SyntheticComparisonFactory(object):
+
+    @contract
+    def makeEqualFunction(self, originalEqualFunction, syntheticMemberList):
+        """
+        :param list(SyntheticMember) syntheticMemberList: a list of the class' synthetic members.
+        """
+        def equal(instance, other):
+            if instance.__class__ is not other.__class__:
+                return NotImplemented
+
+            for m in syntheticMemberList:
+                if getattr(instance, m.privateMemberName()) != getattr(other, m.privateMemberName()):
+                    return False
+
+            if inspect.isfunction(originalEqualFunction) or inspect.ismethod(originalEqualFunction):
+                return originalEqualFunction(instance, other)
+
+            return True
+
+        return equal
+
+    @contract
+    def makeNotEqualFunction(self, originalNotEqualFunction, syntheticMemberList):
+        """
+        :param list(SyntheticMember) syntheticMemberList: a list of the class' synthetic members.
+        """
+
+        def not_equal(instance, other):
+            if instance.__class__ is not other.__class__:
+                return NotImplemented
+
+            for m in syntheticMemberList:
+                if getattr(instance, m.privateMemberName()) != getattr(other, m.privateMemberName()):
+                    return True
+
+            if inspect.isfunction(originalNotEqualFunction) or inspect.ismethod(originalNotEqualFunction):
+                return originalNotEqualFunction(instance, other)
+
+            return False
+
+        return not_equal
+
+    @contract
+    def makeHashFunction(self, originalHashFunction, syntheticMemberList):
+        """
+        :param list(SyntheticMember) syntheticMemberList: a list of the class' synthetic members.
+        """
+        if originalHashFunction is None:
+            return None
+
+        for member in syntheticMemberList:
+            if not member.readOnly():
+                return None
+
+        # All synthetic members are read-only: generate a hash function.
+        def hash_function(instance):
+            values = [getattr(instance, m.privateMemberName()) for m in syntheticMemberList]
+            if inspect.isfunction(originalHashFunction) or inspect.ismethod(originalHashFunction):
+                values.append(originalHashFunction(instance))
+            return hash(tuple(values))
+
+        return hash_function

--- a/synthetic/synthetic_decorator_factory.py
+++ b/synthetic/synthetic_decorator_factory.py
@@ -53,6 +53,14 @@ class SyntheticDecoratorFactory:
 
             return cls
         return functionWrapper
+
+    def syntheticEqualityDecorator(self):
+        def functionWrapper(cls):
+            # This will be used to configure that equality operations should be generated
+            SyntheticClassController(cls).synthesizeEquality()
+
+            return cls
+        return functionWrapper
     
     def namingConventionDecorator(self, namingConvention):
         """

--- a/synthetic/synthetic_member.py
+++ b/synthetic/synthetic_member.py
@@ -56,6 +56,9 @@ class SyntheticMember:
     def privateMemberName(self):
         return self._privateMemberName
 
+    def readOnly(self):
+        return self._readOnly
+
     def checkContract(self, argumentName, value):
         # No contract to check.
         if self._contract is None:

--- a/synthetic/synthetic_meta_data.py
+++ b/synthetic/synthetic_meta_data.py
@@ -28,7 +28,8 @@ class DuplicateMemberNameError(SyntheticError):
 
 class SyntheticMetaData:
 
-    def __init__(self, cls, originalConstructor, originalEqualFunction, originalNotEqualFunction, originalHashFuction, originalMemberNameList):
+    def __init__(self, cls, originalConstructor, originalEqualFunction, originalNotEqualFunction, originalHashFuction,
+                 originalMemberNameList):
         """
         :type originalMemberNameList: list(str)
         :type namingConvention: INamingConvention|None

--- a/synthetic/synthetic_meta_data.py
+++ b/synthetic/synthetic_meta_data.py
@@ -28,20 +28,33 @@ class DuplicateMemberNameError(SyntheticError):
 
 class SyntheticMetaData:
 
-    def __init__(self, cls, originalConstructor, originalMemberNameList):
+    def __init__(self, cls, originalConstructor, originalEqualFunction, originalNotEqualFunction, originalHashFuction, originalMemberNameList):
         """
-    :type originalMemberNameList: list(str)
-    :type namingConvention: INamingConvention|None
-"""
+        :type originalMemberNameList: list(str)
+        :type namingConvention: INamingConvention|None
+        """
         self._class = cls
         self._originalConstructor = originalConstructor
+        self._originalEqualFunction = originalEqualFunction
+        self._originalNotEqualFunction = originalNotEqualFunction
+        self._originalHashFunction = originalHashFuction
         self._originalMemberNameList = originalMemberNameList
         self._syntheticMemberList = []
         self._doesConsumeArguments = False
+        self._hasEqualityGeneration = False
         self._namingConvention = None
     
     def originalConstructor(self):
         return self._originalConstructor
+
+    def originalEqualFunction(self):
+        return self._originalEqualFunction
+
+    def originalNotEqualFunction(self):
+        return self._originalNotEqualFunction
+
+    def originalHashFunction(self):
+        return self._originalHashFunction
 
     def originalMemberNameList(self):
         return self._originalMemberNameList
@@ -67,6 +80,13 @@ class SyntheticMetaData:
 
     def setConsumeArguments(self, _consumeArguments):
         self._doesConsumeArguments = _consumeArguments
+
+    def hasEqualityGeneration(self):
+        """Tells if __eq__ and __neq__ functions should be generated"""
+        return self._hasEqualityGeneration
+
+    def setEqualityGeneration(self, equalityGeneration):
+        self._hasEqualityGeneration = equalityGeneration
     
     def namingConvention(self):
         return self._namingConvention

--- a/tests/test_synthetic_equality.py
+++ b/tests/test_synthetic_equality.py
@@ -68,6 +68,22 @@ class TestChildWithReadOnlyMembers(TestIntermediate):
     pass
 
 
+@synthesizeMember('baseMember', readOnly=True)
+@synthesizeMember('baseProperty', readOnly=True)
+@synthesizeConstructor()
+@synthesizeEquality()
+class TestImmutableBase(object):
+    pass
+
+
+@synthesizeMember('childMember', readOnly=True)
+@synthesizeProperty('childProperty', readOnly=True)
+@synthesizeConstructor()
+@synthesizeEquality()
+class TestImmutableChild(TestImmutableBase):
+    pass
+
+
 class TestSynthesizeEquality(unittest.TestCase):
     def assertCompareEqual(self, first, second):
         self.assertEqual(True, first == second)
@@ -175,6 +191,22 @@ class TestSynthesizeEquality(unittest.TestCase):
     def testInheritanceOfMutableClassByImmutableClassIsNotHashable(self):
         first = TestChildWithReadOnlyMembers(readonlyMember=1, readonlyProperty=2)
         self.assertNotIsInstance(first, collections.Hashable)
+
+    def testInheritanceImmutable(self):
+        first = TestImmutableChild(baseMember=1, baseProperty=2, childMember=3, childProperty=4)
+        second = TestImmutableChild(baseMember=1, baseProperty=2, childMember=3, childProperty=4)
+
+        self.assertCompareEqual(first, second)
+        self.assertIsInstance(first, collections.Hashable)
+        self.assertEqual(hash(first), hash(second))
+
+    def testBaseClassHashIsTakenInAccountInChildHash(self):
+        first = TestImmutableChild(baseMember=4, baseProperty=3, childMember=3, childProperty=4)
+        second = TestImmutableChild(baseMember=1, baseProperty=2, childMember=3, childProperty=4)
+
+        self.assertCompareNotEqual(first, second)
+        self.assertIsInstance(first, collections.Hashable)
+        self.assertNotEqual(hash(first), hash(second))
 
     @staticmethod
     def _resetChildInstance(instance):

--- a/tests/test_synthetic_equality.py
+++ b/tests/test_synthetic_equality.py
@@ -1,0 +1,186 @@
+#-*- coding: utf-8 -*-
+#
+# Created on Oct 30, 2016
+#
+from synthetic import synthesizeConstructor, synthesizeEquality, synthesize_equality, synthesizeMember, synthesizeProperty
+import collections
+import unittest
+
+
+@synthesizeMember('minimalistMember')
+@synthesizeProperty('minimalistProperty')
+@synthesizeEquality()
+class TestEquality(object):
+    pass
+
+
+@synthesizeMember('minimalistMember')
+@synthesize_equality()
+@synthesizeProperty('minimalistProperty')
+class TestEqualityRandomDecoratorPosition(object):
+    pass
+
+
+@synthesizeMember('readonlyMember', readOnly=True)
+@synthesizeProperty('readonlyProperty', readOnly=True)
+@synthesizeEquality()
+@synthesizeConstructor()
+class TestImmutable(object):
+    pass
+
+
+@synthesizeMember('minimalistMember')
+@synthesizeProperty('minimalistProperty')
+@synthesizeMember('readonlyMember', readOnly=True)
+@synthesizeProperty('readonlyProperty', readOnly=True)
+@synthesizeEquality()
+@synthesizeConstructor()
+class TestPartiallyMutable(object):
+    pass
+
+
+@synthesizeMember('baseMember')
+@synthesizeProperty('baseProperty')
+@synthesizeEquality()
+class TestBase(object):
+    pass
+
+
+@synthesizeMember('intermediateMember')
+@synthesizeProperty('intermediateProperty')
+@synthesizeEquality()
+class TestIntermediate(TestBase):
+    pass
+
+
+@synthesizeMember('childMember', contract=int)
+@synthesizeProperty('childProperty')
+@synthesizeEquality()
+class TestChild(TestIntermediate):
+    pass
+
+
+@synthesizeMember('readonlyMember', readOnly=True)
+@synthesizeProperty('readonlyProperty', readOnly=True)
+@synthesizeEquality()
+@synthesizeConstructor()
+class TestChildWithReadOnlyMembers(TestIntermediate):
+    pass
+
+
+class TestSynthesizeEquality(unittest.TestCase):
+    def assertCompareEqual(self, first, second):
+        self.assertEqual(True, first == second)
+        self.assertEqual(False, first != second)
+
+    def assertCompareNotEqual(self, first, second):
+        self.assertEqual(False, first == second)
+        self.assertEqual(True, first != second)
+
+    def testMutableTypes(self):
+        for cls in [TestEquality, TestEqualityRandomDecoratorPosition]:
+            first = cls()
+            second = cls()
+
+            # Initial states are equal
+            self.assertCompareEqual(first, second)
+
+            # When setting both data members to the same values, return True
+            first.setMinimalistMember(1)
+            second.setMinimalistMember(1)
+            first.minimalistProperty = 2
+            second.minimalistProperty = 2
+
+            self.assertCompareEqual(first, second)
+
+            # Test on member not being equal
+            first.setMinimalistMember(2)
+            self.assertCompareNotEqual(first, second)
+
+            # Revert to equality
+            first.setMinimalistMember(second.minimalistMember())
+            self.assertCompareEqual(first, second)
+
+            # Test on property not being equal
+            first.minimalistProperty = 1
+            self.assertCompareNotEqual(first, second)
+
+            # Test that these instances of mutable types are not hashable
+            self.assertNotIsInstance(first, collections.Hashable)
+            self.assertRaises(TypeError, lambda: hash(first))
+
+    def testReturnNotEqualOnDifferingTypes(self):
+        first = TestEquality()
+        second = TestEqualityRandomDecoratorPosition()
+
+        first.setMinimalistMember(1)
+        second.setMinimalistMember(1)
+        first.minimalistProperty = 2
+        second.minimalistProperty = 2
+
+        self.assertCompareNotEqual(first, second)
+
+    def testImmutableType(self):
+        first = TestImmutable(readonlyMember=1, readonlyProperty=2)
+        second = TestImmutable(readonlyMember=1, readonlyProperty=2)
+
+        self.assertCompareEqual(first, second)
+        self.assertIsInstance(first, collections.Hashable)
+        self.assertEqual(hash(first), hash(second))
+
+    def testHashFunctionNotTrivial(self):
+        """Ensure that member hashes are not combined with a simple XOR"""
+        first = TestImmutable(readonlyMember=1, readonlyProperty=1)
+        second = TestImmutable(readonlyMember=2, readonlyProperty=2)
+
+        self.assertCompareNotEqual(first, second)
+        self.assertIsInstance(first, collections.Hashable)
+        self.assertNotEqual(hash(first), hash(second))
+
+    def testInheritance(self):
+        first = TestChild()
+        second = TestChild()
+
+        self.assertEqual(True, first == second)
+
+        self._resetChildInstance(first)
+        self._resetChildInstance(second)
+
+        self.assertCompareEqual(first, second)
+
+        first.setBaseMember(2)
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+        first.baseProperty = 1
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+        first.setIntermediateMember(4)
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+        first.intermediateProperty = 3
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+        first.setChildMember(6)
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+        first.childProperty = 5
+        self.assertCompareNotEqual(first, second)
+        self._resetChildInstance(first)
+
+    def testInheritanceOfMutableClassByImmutableClassIsNotHashable(self):
+        first = TestChildWithReadOnlyMembers(readonlyMember=1, readonlyProperty=2)
+        self.assertNotIsInstance(first, collections.Hashable)
+
+    @staticmethod
+    def _resetChildInstance(instance):
+        instance.setBaseMember(1)
+        instance.baseProperty = 2
+        instance.setIntermediateMember(3)
+        instance.intermediateProperty = 4
+        instance.setChildMember(5)
+        instance.childProperty = 6


### PR DESCRIPTION
As previously discussed, here is my contribution for adding synthetic equality comparisons to PySynthetic.

I have tried to mostly conform to the existing style and conventions, except on these points (which can, of course, be reverted):
- The docstring indentation in most functions hurts my eyes, I think that uniform indentation would be better, and conforms to [PEP 257](https://www.python.org/dev/peps/pep-0257/) ("The entire docstring is indented the same as the quotes at its first line")
- When I created classes, I have used new-style classes instead of old-style, because it has become the norm since Python 2.2. (However, as the class hierarchy of pysynthetic classes is not complex, and as no class uses descriptors, it does not make a practical difference, even in Python 2.7)
