### PR TITLE
Remove testrepository dependency - it should not be needed.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ license = MIT
 requires-python = >=2.7
 requires-dist =
     pycontracts>=1.7.8
-    testrepository>=0.0.20
 
 [files]
 packages = synthetic


### PR DESCRIPTION
I believe the `testrepository` dependency should not be included in the installation requirements for `pysynthetic` - hell, it is not used even for the unit tests of the module !

I could not observe any issues when installing pysynthetic version 0.4.13 (that does not include the dependency).