### PR TITLE
Remove d2to1 requirement

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,11 @@ author = Younes JAAIDI
 author_email = yjaaidi@gmail.com
 maintainer = Younes JAAIDI
 maintainer_email = yjaaidi@gmail.com
-home_page = https://github.com/yjaaidi/pysynthetic
+url = https://github.com/yjaaidi/pysynthetic
 download_url = https://pypi.python.org/pypi/pysynthetic/
-summary = Easy Python class writing and type checking
-description-file = README.rst
-classifier =
+description = Easy Python class writing and type checking
+long_description = file: README.rst
+classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 2
@@ -17,12 +17,12 @@ classifier =
     Topic :: Software Development
     Topic :: Software Development :: Code Generators
     Topic :: Utilities
-platform = any
+platforms = any
 license = MIT
-requires-python = >=2.7
-requires-dist =
-    pycontracts>=1.7.8
 
-[files]
+[options]
+python_requires = >=2.7
+install_requires =
+    pycontracts>=1.7.8
 packages = synthetic
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-setup(setup_requires=['d2to1'],
-      tests_require = ['mock', 'nose'],
-      test_suite = 'nose.collector',
-      d2to1=True)
+setup(tests_require = ['mock', 'nose'],
+      test_suite = 'nose.collector')


### PR DESCRIPTION
d2to1 was required for support of setup.cfg, but setup.cfg has been supported in
setuptools since 2016.

Removing this dependency makes it easier to build the project in contexts where the official
pypi.org mirror is not available.

Here are more details about the issue:
 * When installing `pysynthetic`, `setuptools` runs the `setup.py` file ;
 * `setuptools` detects that the `d2to1` dependency is required, and proceeds to request it;
 * the issue is that the installation routines in `setuptools` only work if the pypi.org public repository is available - if one is behind a corporate firewall that blocks access to pypi.org, then the installation of `pysynthetic` fails;
 * the only easy workaround that I have found for that issue is to ensure that `d2to1` is installed before attempting to install `pysynthetic`;

Shipping a wheel package on pypi would also alleviate the underlying issue of "ease of installation behind a corporate firewall", but I think that it would probably be easier to remove `d2to1` and call it a day, seeing that according to the [`setuptools` documentation](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), `setup.cfg` is supported in core `setuptools` since 2016.